### PR TITLE
Update api_eox.py

### DIFF
--- a/util/api_eox.py
+++ b/util/api_eox.py
@@ -92,7 +92,7 @@ class ApiEox():
 
         self.items = list({pid for pid in pids if pid.lower() not in BLACK_LIST})
 
-        API_URL = 'https://api.cisco.com/supporttools/eox/rest/5/EOXByProductID/{}/{}'
+        API_URL = 'https://apix.cisco.com/supporttools/eox/rest/5/EOXByProductID/{}/{}'
 
         start_index = 0
         end_index = MAX_ITEMS


### PR DESCRIPTION
apix.cisco.com instead of api.cisco.com is required for new API keys since March: https://apiconsole.cisco.com/docs/read/overview/Migrating_Applications